### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -23,7 +23,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Configure Git Safe Directory
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -52,7 +52,7 @@ jobs:
           
       - name: Post to Slack
         if: always()
-        uses: huggingface/transformers/.github/actions/post-slack@main
+        uses: huggingface/transformers/.github/actions/post-slack@6abd9725ee7d809dc974991f8ff6c958afb63a3a  # main
         with:
           slack_channel: "C06ALV91VML"  # channel: #bnb-daily-ci-collab
           title: 🤗 Results of the bitsandbytes tests


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `tests-pr.yml` | `actions/checkout` | `v3` | `v6.0.2` | `de0fac2e4500…` |
| `tests-pr.yml` | `huggingface/transformers/.github/actions/post-slack` | `main` | `main` | `6abd9725ee7d…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#73